### PR TITLE
Importatnt bug fixes and refactoring in emulator.

### DIFF
--- a/Brainfuck/inc/memory_state.h
+++ b/Brainfuck/inc/memory_state.h
@@ -9,28 +9,14 @@ namespace bf {
 	/*CPU's memory. Has a size and type specified at compile time and uses std::array to reserve enough space for
 	the data section of memory. As a default handles single bytes as elements.*/
 	template<int SIZE, typename CELL = unsigned char>
-	struct memory {
+	struct memory : public std::array<CELL, SIZE> {
 
-		using cell_t = CELL;
+		using base_type = std::array<CELL, SIZE>;
+		using cell_t = typename base_type::value_type;
 		static constexpr int size_ = SIZE;
 
-		std::array<cell_t, size_> memory_ = { 0 };
-
-		constexpr int size() const { return size_; }
-		constexpr cell_t *data() const { return const_cast<cell_t*>(memory_.data()); }
-
-		cell_t& operator[](int n) { return memory_[n]; }
-		const cell_t& operator[](int n) const { return memory_[n]; }
-
-		cell_t *begin() { return memory_.data(); }
-		cell_t const *begin() const { return memory_.data(); }
-
-		cell_t *end() { return memory_.data()  + memory_.size(); }
-		cell_t const *end() const { memory_.data() + memory_.size(); }
-
 		void reset() {
-			std::memset(memory_.data(), 0, memory_.size());
+			std::memset(this->data(), 0, size_);
 		}
-
 	};
 }

--- a/Brainfuck/inc/syntax_check.h
+++ b/Brainfuck/inc/syntax_check.h
@@ -9,7 +9,8 @@ namespace bf {
 
 	enum class instruction_type : std::uint32_t {
 		invalid = static_cast<std::uint32_t>(-1),
-		inc = 0,
+		nop = 0,
+		inc,
 		dec,
 		left,
 		right,
@@ -21,7 +22,7 @@ namespace bf {
 		out,
 
 		//pseudo instructions added by the optimizer:
-		set_const,
+		load_const,
 
 
 

--- a/Brainfuck/inc/syntax_tree.h
+++ b/Brainfuck/inc/syntax_tree.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "syntax_check.h"
+
 #include <string_view>
 #include <vector>
 #include <string>
@@ -9,35 +10,18 @@ namespace bf {
 
 	/*Class holding a list of the intermediate language instructions. Represents a program with capabilities of automatic 
 	jump target relocation. And pseudo-vector interface*/
-	class syntax_tree {
-
-		std::vector<instruction> instructions_;
+	class syntax_tree : public std::vector<instruction> {
 
 	public:
 
 
-		void add_instruction(instruction);
+		void add_instruction(instruction const&);
+		void add_instruction(instruction&&);
+
 		void add_instruction(instruction_type type, int argument, int source_offset);
 
 		void relocate_jump_targets();
 
-
-		//pseudo-vector-interface
-		int size() const { return static_cast<int>(instructions_.size()); }
-		instruction* data() { return instructions_.data(); }
-		instruction const* data() const { return instructions_.data(); }
-
-		instruction& operator[](int offset) { return instructions_[offset]; }
-		instruction const& operator[](int offset) const { return instructions_[offset]; }
-
-		decltype(instructions_)::const_iterator begin() const { return instructions_.begin(); };
-		decltype(instructions_)::const_iterator end() const { return instructions_.end(); };
-
-		decltype(instructions_)::iterator begin() { return instructions_.begin(); };
-		decltype(instructions_)::iterator end() { return instructions_.end(); };
-
-		void reserve(int capacity) { instructions_.reserve(capacity); }
-		void swap(syntax_tree & rhs) { instructions_.swap(rhs.instructions_); }
 	};
 
 

--- a/Brainfuck/src/syntax_check.cpp
+++ b/Brainfuck/src/syntax_check.cpp
@@ -15,17 +15,18 @@
 namespace bf {
 
 	bool instruction::is_foldable() const {
-		static std::unordered_set<instruction_type> foldable{
-			instruction_type::dec,
+		static std::unordered_set<instruction_type> const foldable {
 			instruction_type::inc,
-			instruction_type::right,
-			instruction_type::left
+			instruction_type::dec,
+			instruction_type::left,
+			instruction_type::right
 		};
 		return foldable.count(type_);
 	}
 
 	std::ostream& operator<<(std::ostream& str, instruction_type t) {
 		static std::unordered_map<instruction_type, const char*> strings = {
+			{instruction_type::nop,                  "nop"},
 			{instruction_type::inc,					 "inc"},
 			{instruction_type::dec,					 "dec"},
 			{instruction_type::left,			    "left"},
@@ -34,7 +35,8 @@ namespace bf {
 			{instruction_type::loop_end,		"loop_end"},
 			{instruction_type::in,					 "in" },
 			{instruction_type::out,					 "out"},
-			{instruction_type::breakpoint,    "breakpoint"}
+			{instruction_type::breakpoint,    "breakpoint"},
+			{instruction_type::load_const,     "load_const"}
 		};
 		assert(strings.count(t));
 

--- a/Brainfuck/src/syntax_tree.cpp
+++ b/Brainfuck/src/syntax_tree.cpp
@@ -5,27 +5,33 @@
 
 namespace bf {
 
-	void syntax_tree::add_instruction(instruction i) {
-		instructions_.emplace_back(std::move(i));
+
+	void syntax_tree::add_instruction(instruction const&i) {
+		push_back(i);
+	}
+
+	void syntax_tree::add_instruction(instruction && i) {
+		push_back(i);
 	}
 
 	void syntax_tree::add_instruction(instruction_type type, int argument, int source_offset) {
-		instructions_.emplace_back(type, argument, source_offset);
+		emplace_back(type, argument, source_offset);
 	}
+
 
 	void syntax_tree::relocate_jump_targets() {
 
 		std::stack<int> loops;
 
-		for (int offset = 0; offset < size(); offset++)
-			if (instruction_type type = instructions_[offset].type_; type == instruction_type::loop_begin) //open new loop
+		for (int offset = 0; offset < static_cast<int>(size()); offset++)
+			if (instruction_type type = at(offset).type_; type == instruction_type::loop_begin) //open new loop
 				loops.push(offset); //save this bracket's offset
 			else if (type == instruction_type::loop_end) {//if we find an end, set targets for both opening as well as closing bracket
 				assert(!loops.empty());
-				instructions_[loops.top()].argument_ = offset + 1;
-				instructions_[offset].argument_ = loops.top() + 1;
+				at(loops.top()).argument_ = offset + 1;
+				at(offset).argument_ = loops.top() + 1;
 				loops.pop(); //and close the loop
-			}//other instructions are ignored
+			} //other instructions are ignored
 
 		assert(loops.empty()); //Valid program must have empty loop stack
 	}

--- a/README.md
+++ b/README.md
@@ -90,18 +90,18 @@ This toolchain is fully compliant with the Brainfuck language's specification at
 
 		++++++++++          //Set the first cell to 10
 		[-					//loop 10 times setting the values of following cells in the process
-		>+++++++
-		>++++++++++
-		>+++++++++++
-		>+++++++++++
-		>+++++++++++
-		>+++
-		>++++++++++++
-		>+++++++++++
-		>+++++++++++
-		>+++++++++++
-		>++++++++++
-		>+++
+		>+++++++			H
+		>++++++++++			e	
+		>+++++++++++		l
+		>+++++++++++		l
+		>+++++++++++		o
+		>+++				 
+		>++++++++++++		w
+		>+++++++++++		o
+		>+++++++++++		r
+		>+++++++++++		l
+		>++++++++++			d
+		>+++				!
 		<<<<<<<<<<<<          //Return to the loop variable
 		]
 		>++					//set the cells 1 to 12 to the right values of ASCII chars "Hello world!"


### PR DESCRIPTION
Refactoring standard streams for emulaterd programs - pointers to streams are now member variables of the emulator, they are no longer globals.

Rename of emulator flag suppress_stop_notification to suppress_stop_interrupt.
New instruction nop - no operation, rename set_const to load_const.
Refactoring of memory and syntax_tree to inherit the container directly -> removal of redundant delegating method calls and pseudo-vector/array interface.
Minor changes in emulator_cli.cpp required due to the changes to execution::cpu_emulator interface.
Fixed a bug, when moving CPR too far past the boundaries of memory would cause access violation - the position is now being adjusted in a loop until a valid address space is reached.
The emulator now counts how maay instructions have been executed using the executed_instruction_counter_.
New code for the load_const instruction.
Fixed a bug which caused the emulator to switch to the halt state, but not raise the halt flag allowing the execution to proceed.